### PR TITLE
Hotfix: Remove debugger in articles controller

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -10,7 +10,6 @@ class Api::V1::ArticlesController < ApplicationController
   end
 
   def create
-    binding.pry
     @article = current_user.articles.build(article_params)
     @article.user_ids = current_user.id
 


### PR DESCRIPTION
Hotfix https://ssu-jira.softserveinc.com/browse/LVUIDF-31
Removed ```binding.pry``` in Articles controller 

To review:
- [x] @rtriska
- [ ] @vyshnevska
- [x] @forecome 

To merge:
- [ ] @izagor
- [x] @forecome 